### PR TITLE
Adds the optional pronunciation dictionary option

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "firebot-script-elevenlabs-tts",
 	"scriptOutputName": "elevenlabs-tts",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"description": "A custom script that allows ElevenLabs TTS to be used in Firebot",
 	"main": "",
 	"scripts": {

--- a/src/eleven-labs-api.ts
+++ b/src/eleven-labs-api.ts
@@ -56,6 +56,11 @@ export interface ElevenLabsDialogueInput {
 	text: string;
 }
 
+export interface ElevenLabsPronunciationDictionaryLocator {
+	pronunciation_dictionary_id: string;
+	version_id?: string;
+}
+
 interface ElevenLabsVoice extends ElevenLabsVoiceBase {
 	available_for_tiers: string[];
 	fine_tuning: {
@@ -163,7 +168,8 @@ export default class ElevenLabs {
 		similarity = 0.75,
 		model = ElevenLabs.getDefaultModel(),
 		style = 0,
-		speakerBoost = false
+		speakerBoost = false,
+		pronunciationDictionaryLocators
 	}: {
 		voiceId?: string,
 		fileName: string,
@@ -173,7 +179,8 @@ export default class ElevenLabs {
 		similarity?: number,
 		model?: Model,
 		style?: number,
-		speakerBoost?: boolean
+		speakerBoost?: boolean,
+		pronunciationDictionaryLocators?: ElevenLabsPronunciationDictionaryLocator[]
 	}) {
 		if (!fileName) {
 			modules.logger.error('Missing parameter {fileName}');
@@ -203,7 +210,10 @@ export default class ElevenLabs {
 					style,
 					use_speaker_boost: speakerBoost
 				},
-				model_id: model.id
+				model_id: model.id,
+				...(pronunciationDictionaryLocators?.length
+					? { pronunciation_dictionary_locators: pronunciationDictionaryLocators }
+					: {})
 			})
 		};
 
@@ -230,12 +240,14 @@ export default class ElevenLabs {
 		fileName,
 		inputs,
 		model = ElevenLabs.getModelByID('eleven_v3'),
-		stability = '0.5'
+		stability = '0.5',
+		pronunciationDictionaryLocators
 	}: {
 		fileName: string,
 		inputs: ElevenLabsDialogueInput[],
 		model?: Model,
-		stability?: string
+		stability?: string,
+		pronunciationDictionaryLocators?: ElevenLabsPronunciationDictionaryLocator[]
 	}) {
 		if (!fileName) {
 			modules.logger.error('Missing parameter {fileName}');
@@ -263,7 +275,10 @@ export default class ElevenLabs {
 			body: JSON.stringify({
 				inputs,
 				model_id: model.id,
-				stability
+				stability,
+				...(pronunciationDictionaryLocators?.length
+					? { pronunciation_dictionary_locators: pronunciationDictionaryLocators }
+					: {})
 			})
 		};
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -28,7 +28,7 @@ const script: Firebot.CustomScript<Params> = {
 			name: 'ElevenLabs TTS',
 			description: 'A custom script that allows ElevenLabs TTS to be used in Firebot',
 			author: 'Lordmau5',
-			version: '1.4.0',
+			version: '1.5.0',
 			firebotVersion: '5'
 		};
 	},

--- a/src/request-dialogue.effect.ts
+++ b/src/request-dialogue.effect.ts
@@ -38,6 +38,8 @@ interface EffectModel {
 
 	stability: string;
 
+	pronunciationDictionaryId: string;
+
 	waitForGeneration: boolean;
 }
 
@@ -65,6 +67,10 @@ const effect: EffectType<EffectModel> = {
 
 		if ($scope.effect.splitText == null) {
 			$scope.effect.splitText = '--';
+		}
+
+		if ($scope.effect.pronunciationDictionaryId == null) {
+			$scope.effect.pronunciationDictionaryId = '';
 		}
 
 		if ($scope.effect.voices == null) {
@@ -249,12 +255,18 @@ const effect: EffectType<EffectModel> = {
 				}
 			}
 
+			const dictId = effect.pronunciationDictionaryId?.trim();
+			const pronunciationDictionaryLocators = dictId
+				? [{ pronunciation_dictionary_id: dictId }]
+				: undefined;
+
 			const tts = api.textToDialogue({
 				fileName: mp3Path,
 				inputs,
 				// For now this is only supported on the v3 model.
 				model: ElevenLabs.getModelByID('eleven_v3'),
-				stability: effect.stability
+				stability: effect.stability,
+				pronunciationDictionaryLocators
 			});
 
 			tts_promises.set(ttsToken, tts);

--- a/src/request-dialogue.html
+++ b/src/request-dialogue.html
@@ -92,6 +92,15 @@
 		options="{ '0.0': 'Creative (0.0)', '0.5': 'Natural (0.5)', '1.0': 'Robust (1.0)' }" placeholder="0.5" />
 </eos-container>
 
+<eos-container header="Pronunciation Dictionary" pad-top="true">
+	<p>
+		Optional. The ID of an ElevenLabs pronunciation dictionary to apply to this dialogue.
+		Leave blank to use none. The latest version of the dictionary is always used.
+	</p>
+	<firebot-input model="effect.pronunciationDictionaryId" input-type="string" disable-variables="true"
+		placeholder-text="Enter a pronunciation dictionary ID (optional)"></firebot-input>
+</eos-container>
+
 <eos-container header="Voice Matches" pad-top="true">
 	<p>
 		The names are separated by a comma (,) so you could do "John, James, Jeremy" and it would allow you to do TTS

--- a/src/request-tts.effect.ts
+++ b/src/request-tts.effect.ts
@@ -31,6 +31,8 @@ interface EffectModel {
 	model: Model;
 	speakerBoost: boolean;
 
+	pronunciationDictionaryId: string;
+
 	waitForGeneration: boolean;
 }
 
@@ -66,6 +68,10 @@ const effect: EffectType<EffectModel> = {
 
 		if ($scope.effect.style == null) {
 			$scope.effect.style = 0;
+		}
+
+		if ($scope.effect.pronunciationDictionaryId == null) {
+			$scope.effect.pronunciationDictionaryId = '';
 		}
 
 		const models = backendCommunicator.fireEventSync('elevenlabs-get-models');
@@ -158,6 +164,11 @@ const effect: EffectType<EffectModel> = {
 		}
 
 		try {
+			const dictId = effect.pronunciationDictionaryId?.trim();
+			const pronunciationDictionaryLocators = dictId
+				? [{ pronunciation_dictionary_id: dictId }]
+				: undefined;
+
 			const tts = api.textToSpeech({
 				voiceId,
 				fileName: mp3Path,
@@ -167,7 +178,8 @@ const effect: EffectType<EffectModel> = {
 				similarity: effect.similarity,
 				style: effect.style,
 				speakerBoost: effect.speakerBoost,
-				model
+				model,
+				pronunciationDictionaryLocators
 			});
 
 			tts_promises.set(ttsToken, tts);

--- a/src/request-tts.html
+++ b/src/request-tts.html
@@ -146,6 +146,18 @@
 	</label>
 </eos-container>
 
+<eos-container header="Pronunciation Dictionary" pad-top="true">
+	<p>
+		Optional. The ID of an ElevenLabs pronunciation dictionary to apply to this TTS request.
+		Leave blank to use none. The latest version of the dictionary is always used.
+		<br>
+		Note: phoneme-based rules only work on the Flash v2 / Monolingual v1 models, while
+		alias-based rules work on all models.
+	</p>
+	<firebot-input model="effect.pronunciationDictionaryId" input-type="string" disable-variables="true"
+		placeholder-text="Enter a pronunciation dictionary ID (optional)"></firebot-input>
+</eos-container>
+
 <eos-container header="Wait For Generation" pad-top="true">
 	<p>
 		Waits for the generation to finish before continuing with other effects.


### PR DESCRIPTION
Eleven Labs API supports optional dictionaries that create consistency in the pronunciation of words. This commit adds support for the dictionary field (max 1 dictionary for simplicity) to the request dialog and request tts effects and scripts.

<img width="1120" height="587" alt="image" src="https://github.com/user-attachments/assets/8f231860-4bcc-4f6a-ab36-970f2e85e19f" />

Requests a bump to 1.5, adding new functionality. When the the field isn't included, it's omitted from the request so that its maintains backwards compatibility.